### PR TITLE
site doesn't scroll on mobile

### DIFF
--- a/_layouts/front_page.html
+++ b/_layouts/front_page.html
@@ -7,7 +7,7 @@
 
   <div id="skrollr-body" >
 
-    <header id="codefreeze.fi"
+    <header id="codefreeze_fi"
             class="b-header"
     ><div class="b-header__img b-img b-img_header b-header__title-container b-img_full-sized b-img_parallax"
           data-center="background-position: 50% 0px;"
@@ -17,7 +17,7 @@
       <div class="image-container flex flex-vertical"
            data-start="opacity: 0.9999"
            data-40-top="opacity: 0"
-           data-anchor-target="#codefreeze.fi .h1"
+           data-anchor-target="#codefreeze_fi .h1"
       >
         <h1 hidden="hidden" aria-hidden="true" style="display: none"><span class="snowflake">&#10052;</span><br><span>CodeFreeze</span> </h1>
         <a href="/"class="h1 b-title"><span class="b-title__snowflake">&#10052;</span><span class='b-title__name'>CodeFreeze</span></a>


### PR DESCRIPTION
use html/css id with _ instead of dot (.)
while it's ok to use a html id with a dot inside it can lead to problems with css selectors. 
jquery.min.js:2 Uncaught Unable to find anchor target "#codefreeze.fi .h1"