### PR TITLE
postpone codefreeze 2021

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: 2018
 title: Codefreeze
 tagline: Prepare for your last commit
-when: Sat Jan 9th - Sat 16th 2021
+when: Not before Jan 2022
 where: Kiilopää, Finland
 where_link: https://www.kiilopaa.fi/en/
 description: Codefreeze is an unconference with very little structure. Actually, it’s not a conference at all. Codefreeze is a time and place for software craftspeople to meet.


### PR DESCRIPTION
to avoid confusion for possible participants
