### PR TITLE
feat(matrix): add quotation marks to matrix accounts

### DIFF
--- a/_participants/jbarop.md
+++ b/_participants/jbarop.md
@@ -5,5 +5,5 @@ pronouns: he/him
 room-type: [quadruple (with TBD)]
 mastodon: https://chaos.social/@jbarop
 linkedin: https://www.linkedin.com/in/jbarop
-matrix: @jbarop:matrix.im
+matrix: "@jbarop:matrix.im"
 ---

--- a/_participants/markus.md
+++ b/_participants/markus.md
@@ -7,5 +7,5 @@ image: https://images.contentful.com/bncv3c2gt878/6CWMgqeZdCmkk6KkIUksgQ/5092209
 contact-via: m@coderbyheart.com
 room-type: big cabin with Aki
 linkedin: https://www.linkedin.com/in/markustacker
-matrix: @coderbyheart:matrix.im
+matrix: "@coderbyheart:matrix.im"
 ---


### PR DESCRIPTION
I am sure that the matrix info worked yesterday without quotation marks. But apparently not?

I suspect that "@" is a special character. But couldn't find anything about it.