### PR TITLE
fix mastodon link

### DIFF
--- a/_participants/RobertKrul.md
+++ b/_participants/RobertKrul.md
@@ -2,6 +2,6 @@
 name: Robert Krul
 contact-via: robert.krul@sintec.de
 room-type: single 
-mastodon: @rkrul@mastodon.social 
+mastodon: https://mastodon.social/@rkrul
 linkedin: https://www.linkedin.com/in/robert-krul-7660742a/
 ---


### PR DESCRIPTION
a mastodon handle is currently not supported and leads to an empty list item for this participant on codefreeze.fi
